### PR TITLE
Change empty values to display null instead of dash string

### DIFF
--- a/source/JSONFaceView.mc
+++ b/source/JSONFaceView.mc
@@ -11,6 +11,7 @@ class JSONFaceView extends WatchUi.WatchFace {
     private var COLOR_KEYS = 0xff0055;
     private var COLOR_GREEN_STRING = 0x00aa00;
     private var COLOR_ORANGE_NUMBER = 0xffaa00;
+    private var COLOR_PURPLE_NULL = 0xae81ff;
     private var FONT = Graphics.FONT_XTINY;
 
     private var KEY_HEADER_FILENAME_X = "HEADER_FILENAME_X";
@@ -158,7 +159,7 @@ class JSONFaceView extends WatchUi.WatchFace {
 
         var keyWithQuotes = "\""+key+"\"";
         var valueWithQuotes = "\""+value+"\"";
-        var valueText = value.toString();
+        var valueText = value == null ? "null" : value.toString();
 
         drawKeyText(dc, x, y, keyWithQuotes);
         
@@ -167,7 +168,10 @@ class JSONFaceView extends WatchUi.WatchFace {
         drawPlainText(dc, twoPointsX , y, ":");
 
         var valueX = twoPointsX + dc.getTextDimensions(":", FONT)[0] + positions.get(KEY_JSON_GAP_SIZE);
-        if(value instanceof Toybox.Lang.String){
+        if(value == null) {
+            drawNullText(dc, valueX, y, valueText);
+        }
+        else if(value instanceof Toybox.Lang.String){
             valueText = valueWithQuotes;
             drawStringText(dc, valueX, y, valueText);
         }else if(value instanceof Toybox.Lang.Number){
@@ -203,6 +207,11 @@ class JSONFaceView extends WatchUi.WatchFace {
         dc.drawText(x, y, FONT, content , Graphics.TEXT_JUSTIFY_LEFT);
     }
 
+    private function drawNullText(dc, x, y, content){
+        dc.setColor(COLOR_PURPLE_NULL, Graphics.COLOR_TRANSPARENT);
+        dc.drawText(x, y, FONT, content , Graphics.TEXT_JUSTIFY_LEFT);
+    }
+
     private function drawStringText(dc, x, y, content){
         dc.setColor(COLOR_GREEN_STRING, Graphics.COLOR_TRANSPARENT);
         dc.drawText(x, y, FONT, content , Graphics.TEXT_JUSTIFY_LEFT);
@@ -232,20 +241,20 @@ class JSONFaceView extends WatchUi.WatchFace {
 
     private function getStepCount() {
         var stepCount = ActivityMonitor.getInfo().steps;
-        return stepCount == null ? "--" : stepCount;
+        return stepCount;
     }
 
     private function getDistance() {
         var distance = ActivityMonitor.getInfo().distance;
         
         // Distance is in cm, convert to km
-        return distance == null ? "--" : distance/100000.0;
+        return distance == null ? null : distance/100000.0;
     }
 
 
     private function getHeartRate() {
         // initialize it to null
-        var heartRate = "--";
+        var heartRate = null;
 
         // Get the activity info if possible
         var info = Activity.getActivityInfo();
@@ -260,7 +269,7 @@ class JSONFaceView extends WatchUi.WatchFace {
         }
 
         // Could still be null if the device doesn't support it
-        return heartRate == null ? "--" : heartRate.toNumber();
+        return heartRate == null ? null : heartRate.toNumber();
     }
 
     private function getBattery() {


### PR DESCRIPTION
Hi again!

I have a small PR this time that changes "--" for empty values to null value. I think that this fits json format better as values can be null while "--" mean a totaly different value type from the one used when there is a value to be displayed. For example hear rate is a number but when the value is no longer present it changes to string.

Feel free to reject this PR if you don't agree and/or change null value color.

Right now this mainly applies to hr but I intend to add more features and then null will be displayed more often (for example for bodyBattery and hr when you take off the watch or for temperature when there is no phone to sync data for a longer time).

![obraz](https://github.com/aguilarguisado/JSONFace/assets/9075889/75dcbcf6-96be-4b5c-bf49-bae36c6287c0)
